### PR TITLE
feat: company-service 설정 및 초기 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/yeoljeong/tripmate/CompanyServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/CompanyServiceApplication.java
@@ -2,7 +2,9 @@ package com.yeoljeong.tripmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
+@EnableDiscoveryClient
 @SpringBootApplication
 public class CompanyServiceApplication {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=company-service

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ server:
 eureka:
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVER_URL}
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka}
   instance:
     instance-id:
       ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: company-service
+
+server:
+  port: 0
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL}
+  instance:
+    instance-id:
+      ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- Eureka에 company-service가 등록될 수 있는 설정을 추가
- 포트번호 추가 (0번 변동포트)

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- yaml 설정에 동적 포트 번호를 설정 (port: 0)
- 설정 클래스에 @EnableDiscoveryClien 추가 
- gitignotre 에 .env추가 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled service discovery/registration for better microservice communication.
  * Services now start on an ephemeral port by default and use dynamic instance identifiers.
  * Eureka connection can be configured via an environment variable with a sensible localhost fallback.

* **Chores**
  * Added support for environment-file usage and ignored local .env files.
  * Updated runtime configuration and dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->