### PR TITLE
Feature/23 schedule create controller

### DIFF
--- a/http/product.http
+++ b/http/product.http
@@ -1,8 +1,9 @@
-@port = 50599
+@port = 57869
 @host = http://localhost:{{port}}
 @companyId = 278a96ab-0527-492e-9e96-b4bd0235ddb8
 @userId = 00000000-0000-0000-0000-000000000000
-@productId = fd20fbb6-59d9-4651-bcbb-aa7fad3f2706
+@productId = f115373c-ca77-4cd8-9f81-2b62318e71ab
+
 ### 상품 생성
 POST {{host}}/products
 Content-Type: application/json
@@ -10,7 +11,7 @@ X-User-Id: {{userId}}
 X-Company-Id: {{companyId}}
 
 {
-  "productName": "테스트 상품2",
+  "productName": "테스트 상품3",
   "description": "테스트 상품 설명",
   "country": "KR",
   "state": "서울특별시",
@@ -26,3 +27,13 @@ GET {{host}}/products/{{productId}}
 
 ### 상품 목록 조회
 GET {{host}}/products?page=0&size=10&sort=createdAt,desc
+
+### 상품 스케줄 일괄 생성
+POST {{host}}/products/{{productId}}/schedules/bulk
+Content-Type: application/json
+
+{
+  "startDate": "2026-05-01",
+  "endDate": "2026-05-05",
+  "stock": 10
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/application/service/command/ProductScheduleCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/application/service/command/ProductScheduleCommandService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class ProductScheduleCommandService {
+public class ProductScheduleCommandService {
 
   private final ProductRepository productRepository;
   private final ProductScheduleRepository scheduleRepository;

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
@@ -1,11 +1,12 @@
 package com.yeoljeong.tripmate.product.presentation.controller.external;
 
-import com.yeoljeong.tripmate.product.application.dto.command.CreateProductScheduleCommand;
 import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleResult;
 
 import com.yeoljeong.tripmate.product.application.service.command.ProductScheduleCommandService;
 import com.yeoljeong.tripmate.product.presentation.dto.request.ProductScheduleRequest;
 import com.yeoljeong.tripmate.product.presentation.dto.response.ProductScheduleResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class ProductScheduleController {
 
   //상품 스케줄 일괄 생성
   @PostMapping("/{productId}/schedules/bulk")
-  public ResponseEntity<ProductScheduleResponse> createSchedules(
+  ResponseEntity<ApiResponse<ProductScheduleResponse>> createSchedules(
       @PathVariable UUID productId,
       @RequestBody ProductScheduleRequest request
   ) {
@@ -32,7 +33,10 @@ public class ProductScheduleController {
     ProductScheduleResult result =
         scheduleCommandService.createSchedules(request.toCommand(productId));
 
-    return ResponseEntity.ok(ProductScheduleResponse.from(result));
-  }
-  }
+    ProductScheduleResponse response = ProductScheduleResponse.from(result);
 
+    return ResponseEntity.ok(
+        ApiResponse.success(CommonSuccessCode.OK, response)
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
@@ -1,0 +1,38 @@
+package com.yeoljeong.tripmate.product.presentation.controller.external;
+
+import com.yeoljeong.tripmate.product.application.dto.command.CreateProductScheduleCommand;
+import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleResult;
+
+import com.yeoljeong.tripmate.product.application.service.command.ProductScheduleCommandService;
+import com.yeoljeong.tripmate.product.presentation.dto.request.ProductScheduleRequest;
+import com.yeoljeong.tripmate.product.presentation.dto.response.ProductScheduleResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products")
+public class ProductScheduleController {
+
+  private final ProductScheduleCommandService scheduleCommandService;
+
+  //상품 스케줄 일괄 생성
+  @PostMapping("/{productId}/schedules/bulk")
+  public ResponseEntity<ProductScheduleResponse> createSchedules(
+      @PathVariable UUID productId,
+      @RequestBody ProductScheduleRequest request
+  ) {
+
+    ProductScheduleResult result =
+        scheduleCommandService.createSchedules(request.toCommand(productId));
+
+    return ResponseEntity.ok(ProductScheduleResponse.from(result));
+  }
+  }
+

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/request/ProductScheduleRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/request/ProductScheduleRequest.java
@@ -1,0 +1,27 @@
+package com.yeoljeong.tripmate.product.presentation.dto.request;
+
+import com.yeoljeong.tripmate.product.application.dto.command.CreateProductScheduleCommand;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductScheduleRequest {
+
+  private UUID productId;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private int stock;
+
+  //Request → Command 변환
+  public CreateProductScheduleCommand toCommand(UUID productId) {
+    return CreateProductScheduleCommand.builder()
+        .productId(productId)
+        .startDate(startDate)
+        .endDate(endDate)
+        .stock(stock)
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/request/ProductScheduleRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/request/ProductScheduleRequest.java
@@ -1,6 +1,8 @@
 package com.yeoljeong.tripmate.product.presentation.dto.request;
 
 import com.yeoljeong.tripmate.product.application.dto.command.CreateProductScheduleCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Getter;
@@ -10,9 +12,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductScheduleRequest {
 
-  private UUID productId;
+  @NotNull(message = "시작일은 필수입니다.")
   private LocalDate startDate;
+  @NotNull(message = "종료일은 필수입니다.")
   private LocalDate endDate;
+  @Min(value = 1, message = "재고는 1 이상이어야 합니다.")
   private int stock;
 
   //Request → Command 변환

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleResponse.java
@@ -1,0 +1,37 @@
+package com.yeoljeong.tripmate.product.presentation.dto.response;
+
+import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleResult;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class ProductScheduleResponse {
+
+  private final UUID productId;
+  private final int createdCount;
+  private final LocalDate startDate;
+  private final LocalDate endDate;
+
+  private ProductScheduleResponse(
+      UUID productId,
+      int createdCount,
+      LocalDate startDate,
+      LocalDate endDate
+  ) {
+    this.productId = productId;
+    this.createdCount = createdCount;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  //Result → Response 변환
+  public static ProductScheduleResponse from(ProductScheduleResult result) {
+    return new ProductScheduleResponse(
+        result.productId(),
+        result.createdCount(),
+        result.startDate(),
+        result.endDate()
+    );
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 상품 스케줄 일괄 생성 API를 추가하고, 요청/응답 DTO 및 공통 응답(ApiResponse) 구조를 적용
-#23
### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- ProductScheduleController 생성 (일괄 생성 API 추가)
- ProductScheduleRequest / ProductScheduleResponse DTO 추가
- 스케줄 생성 API에 ApiResponse 공통 응답 포맷 적용
- 서비스 결과(Result DTO)를 응답 DTO로 변환하는 로직 추가

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-/products/{productId}/schedules/bulk 경로로 상품별 스케줄 생성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 일정 일괄 생성용 API 추가: POST /products/{productId}/schedules/bulk
  * 시작일(startDate), 종료일(endDate), 재고(stock) 입력으로 여러 일정을 한 번에 생성 가능하며, 생성된 일정 수(createdCount) 및 적용 기간을 응답으로 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->