### PR TITLE
Feature/23 schedule query controller

### DIFF
--- a/http/product.http
+++ b/http/product.http
@@ -1,8 +1,9 @@
-@port = 57869
+@port = 58576
 @host = http://localhost:{{port}}
 @companyId = 278a96ab-0527-492e-9e96-b4bd0235ddb8
 @userId = 00000000-0000-0000-0000-000000000000
 @productId = f115373c-ca77-4cd8-9f81-2b62318e71ab
+@scheduleId = a0969ec0-1eb5-466d-a2b1-004a3b8788eb
 
 ### 상품 생성
 POST {{host}}/products
@@ -37,3 +38,10 @@ Content-Type: application/json
   "endDate": "2026-05-05",
   "stock": 10
 }
+
+### 스케줄 목록 조회
+GET {{host}}/products/{{productId}}/schedules?page=0&size=10
+
+
+### 스케줄 단건 조회
+GET {{host}}/products/{{productId}}/schedules/{{scheduleId}}

--- a/src/main/java/com/yeoljeong/tripmate/product/application/dto/result/ProductScheduleQueryResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/application/dto/result/ProductScheduleQueryResult.java
@@ -10,7 +10,6 @@ import java.util.UUID;
  */
 public record ProductScheduleQueryResult(
     UUID scheduleId,
-    UUID productId,
     LocalDate date,
     int stock,
     String status
@@ -18,7 +17,6 @@ public record ProductScheduleQueryResult(
   public static ProductScheduleQueryResult from(ProductSchedule schedule) {
     return new ProductScheduleQueryResult(
         schedule.getId(),
-        schedule.getProduct().getId(),
         schedule.getDate(),
         schedule.getStock(),
         schedule.getStatus().name()

--- a/src/main/java/com/yeoljeong/tripmate/product/application/service/query/ProductScheduleQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/application/service/query/ProductScheduleQueryService.java
@@ -18,16 +18,16 @@ public class ProductScheduleQueryService {
   private final ProductScheduleRepository scheduleRepository;
 
   // 단건 조회
-  public ProductScheduleQueryResult getSchedule(UUID scheduleId) {
-    ProductSchedule schedule = scheduleRepository.findById(scheduleId)
+  public ProductScheduleQueryResult getSchedule(UUID productId, UUID scheduleId) {
+    ProductSchedule schedule = scheduleRepository.findByIdAndProductId(scheduleId, productId)
         .orElseThrow(() -> new BusinessException(ProductErrorCode.SCHEDULE_NOT_FOUND));
 
     return ProductScheduleQueryResult.from(schedule);
   }
 
-  // 목록  조회
-  public Slice<ProductScheduleQueryResult> getSchedules(Pageable pageable) {
-    return scheduleRepository.findAll(pageable)
+  // 목록 조회
+  public Slice<ProductScheduleQueryResult> getSchedules(UUID productId, Pageable pageable) {
+    return scheduleRepository.findAllByProductId(productId, pageable)
         .map(ProductScheduleQueryResult::from);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/domain/repository/ProductScheduleRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/domain/repository/ProductScheduleRepository.java
@@ -19,4 +19,8 @@ public interface ProductScheduleRepository {
 
   void flush();
 
+  Slice<ProductSchedule> findAllByProductId(UUID productId, Pageable pageable);
+
+  Optional<ProductSchedule> findByIdAndProductId(UUID id, UUID productId);
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/jpa/ProductScheduleJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/jpa/ProductScheduleJpaRepository.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.product.infrastructure.persistence.jpa;
 
 import com.yeoljeong.tripmate.product.domain.model.ProductSchedule;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -8,4 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductScheduleJpaRepository extends JpaRepository<ProductSchedule, UUID> {
   Slice<ProductSchedule> findAllBy(Pageable pageable);
+
+  Slice<ProductSchedule> findAllByProductId(UUID productId, Pageable pageable);
+
+  Optional<ProductSchedule> findByIdAndProductId(UUID id, UUID productId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/repositoryImpl/ProductScheduleRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/repositoryImpl/ProductScheduleRepositoryImpl.java
@@ -41,4 +41,16 @@ public class ProductScheduleRepositoryImpl implements ProductScheduleRepository 
   public Slice<ProductSchedule> findAll(Pageable pageable) {
     return jpaRepository.findAllBy(pageable);
   }
+
+  @Override
+  public Slice<ProductSchedule> findAllByProductId(UUID productId, Pageable pageable) {
+    return jpaRepository.findAllByProductId(productId, pageable);
+  }
+
+  @Override
+  public Optional<ProductSchedule> findByIdAndProductId(UUID id, UUID productId) {
+    return jpaRepository.findByIdAndProductId(id, productId);
+  }
+
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
@@ -2,14 +2,20 @@ package com.yeoljeong.tripmate.product.presentation.controller.external;
 
 import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleCommandResult;
 
+import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleQueryResult;
 import com.yeoljeong.tripmate.product.application.service.command.ProductScheduleCommandService;
+import com.yeoljeong.tripmate.product.application.service.query.ProductScheduleQueryService;
 import com.yeoljeong.tripmate.product.presentation.dto.request.ProductScheduleRequest;
+import com.yeoljeong.tripmate.product.presentation.dto.response.ProductScheduleQueryResponse;
 import com.yeoljeong.tripmate.product.presentation.dto.response.ProductScheduleResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductScheduleController {
 
   private final ProductScheduleCommandService scheduleCommandService;
+  private final ProductScheduleQueryService scheduleQueryService;
 
   //상품 스케줄 일괄 생성
   @PostMapping("/{productId}/schedules/bulk")
@@ -38,5 +45,35 @@ public class ProductScheduleController {
     return ResponseEntity.ok(
         ApiResponse.success(CommonSuccessCode.OK, response)
     );
+  }
+
+  // 스케줄 단건 조회
+  @GetMapping("/{productId}/schedules/{scheduleId}")
+  public ApiResponse<ProductScheduleResponse> getSchedule(
+      @PathVariable UUID productId,
+      @PathVariable UUID scheduleId
+  ) {
+
+    ProductScheduleQueryResult result =
+        scheduleQueryService.getSchedule(productId, scheduleId);
+
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        ProductScheduleQueryResponse.from(result)
+    );
+  }
+
+  // 스케줄 목록 조회
+  @GetMapping("/{productId}/schedules")
+  public ApiResponse<Slice<ProductScheduleResponse>> getSchedules(
+      @PathVariable UUID productId,
+      Pageable pageable
+  ) {
+
+    Slice<ProductScheduleResponse> response =
+        scheduleQueryService.getSchedules(productId, pageable)
+            .map(ProductScheduleQueryResponse::from);
+
+    return ApiResponse.success(CommonSuccessCode.OK, response);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
@@ -49,11 +49,10 @@ public class ProductScheduleController {
 
   // 스케줄 단건 조회
   @GetMapping("/{productId}/schedules/{scheduleId}")
-  public ApiResponse<ProductScheduleResponse> getSchedule(
+  public ApiResponse<ProductScheduleQueryResponse> getSchedule(
       @PathVariable UUID productId,
       @PathVariable UUID scheduleId
   ) {
-
     ProductScheduleQueryResult result =
         scheduleQueryService.getSchedule(productId, scheduleId);
 
@@ -65,12 +64,11 @@ public class ProductScheduleController {
 
   // 스케줄 목록 조회
   @GetMapping("/{productId}/schedules")
-  public ApiResponse<Slice<ProductScheduleResponse>> getSchedules(
+  public ApiResponse<Slice<ProductScheduleQueryResponse>> getSchedules(
       @PathVariable UUID productId,
       Pageable pageable
   ) {
-
-    Slice<ProductScheduleResponse> response =
+    Slice<ProductScheduleQueryResponse> response =
         scheduleQueryService.getSchedules(productId, pageable)
             .map(ProductScheduleQueryResponse::from);
 

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleQueryResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleQueryResponse.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.product.presentation.dto.response;
+
+import com.yeoljeong.tripmate.product.application.dto.result.ProductScheduleQueryResult;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record ProductScheduleQueryResponse(
+    UUID scheduleId,
+    UUID productId,
+    LocalDate date,
+    int stock,
+    String status
+) {
+
+  public static ProductScheduleQueryResponse from(ProductScheduleQueryResult result) {
+    return new ProductScheduleQueryResponse(
+        result.scheduleId(),
+        result.productId(),
+        result.date(),
+        result.stock(),
+        result.status()
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleQueryResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductScheduleQueryResponse.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 public record ProductScheduleQueryResponse(
     UUID scheduleId,
-    UUID productId,
     LocalDate date,
     int stock,
     String status
@@ -15,7 +14,6 @@ public record ProductScheduleQueryResponse(
   public static ProductScheduleQueryResponse from(ProductScheduleQueryResult result) {
     return new ProductScheduleQueryResponse(
         result.scheduleId(),
-        result.productId(),
         result.date(),
         result.stock(),
         result.status()


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 상품 스케줄 단건 및 목록 조회 API를 추가하고, 조회 전용 서비스 및 DTO 구조를 분리하여 구현했습니다
- #23 

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 상품 스케줄 단건 조회 API (GET /products/{productId}/schedules/{scheduleId}) 추가
- 상품 스케줄 목록 조회 API (GET /products/{productId}/schedules) 추가
- ProductScheduleQueryService 구현 (조회 로직 분리)
- ProductScheduleRepository에 조회 메서드 추가
- 조회 전용 DTO (ProductScheduleQueryResult / Response) 생성

- 조회 DTO에서 불필요한 productId 필드 제거
(schedule.getProduct().getId() 호출로 인한 N+1 문제 방지)
(productId는 URL 경로(/products/{productId}/schedules)에서 이미 제공되므로 응답에서 제거)

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품의 스케줄 목록을 페이지네이션을 통해 조회하는 API 엔드포인트 추가
  * 상품 ID와 스케줄 ID를 이용하여 개별 스케줄 정보를 조회하는 API 엔드포인트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->