### PR TITLE
Feat/23 available products controller

### DIFF
--- a/http/product.http
+++ b/http/product.http
@@ -1,4 +1,4 @@
-@port = 58576
+@port = 59090
 @host = http://localhost:{{port}}
 @companyId = 278a96ab-0527-492e-9e96-b4bd0235ddb8
 @userId = 00000000-0000-0000-0000-000000000000
@@ -45,3 +45,7 @@ GET {{host}}/products/{{productId}}/schedules?page=0&size=10
 
 ### 스케줄 단건 조회
 GET {{host}}/products/{{productId}}/schedules/{{scheduleId}}
+
+
+### 날짜 기준 예약 가능한 상품 조회
+GET {{host}}/products/available?date=2026-05-01&page=0&size=10

--- a/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/jpa/ProductScheduleJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/infrastructure/persistence/jpa/ProductScheduleJpaRepository.java
@@ -21,7 +21,10 @@ public interface ProductScheduleJpaRepository extends JpaRepository<ProductSched
 
 
   /**
-   * 특정 날짜에 예약 가능한 스케줄 조회 - status = ACTIVE, stock > 0 인 경우만 조회 - N+1 방지를 위해 product fetch join
+   * 특정 날짜에 예약 가능한 스케줄 조회
+   * - status = ACTIVE,
+   * - stock > 0 인 경우만 조회
+   * - N+1 방지를 위해 product fetch join
    */
 
   @Query("""

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductAvailabilityController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductAvailabilityController.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +25,7 @@ public class ProductAvailabilityController {
   @GetMapping("/available")
   public ApiResponse<Slice<ProductAvailabilityResponse>> getAvailableProducts(
       @RequestParam LocalDate date,
-      Pageable pageable
+      @PageableDefault(size = 10) Pageable pageable
   ) {
     Slice<ProductAvailabilityResponse> response =
         searchService.getAvailableProducts(date, pageable)

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductAvailabilityController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductAvailabilityController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/products")
-public class ProductSearchController {
+public class ProductAvailabilityController {
 
   private final ProductSearchService searchService;
 

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductController.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -53,7 +54,7 @@ public class ProductController {
   // 상품 목록 조회
   @GetMapping
   public ApiResponse<Slice<ProductResponse>> getProducts(
-      Pageable pageable
+      @PageableDefault(size = 10) Pageable pageable
   ) {
     Slice<ProductResponse> response = productQueryService.getProducts(pageable)
         .map(ProductResponse::from);

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductScheduleController.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -66,7 +67,7 @@ public class ProductScheduleController {
   @GetMapping("/{productId}/schedules")
   public ApiResponse<Slice<ProductScheduleQueryResponse>> getSchedules(
       @PathVariable UUID productId,
-      Pageable pageable
+      @PageableDefault(size = 10) Pageable pageable
   ) {
     Slice<ProductScheduleQueryResponse> response =
         scheduleQueryService.getSchedules(productId, pageable)

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductSearchController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/external/ProductSearchController.java
@@ -1,7 +1,16 @@
 package com.yeoljeong.tripmate.product.presentation.controller.external;
 
+import com.yeoljeong.tripmate.product.application.service.query.ProductSearchService;
+import com.yeoljeong.tripmate.product.presentation.dto.response.ProductAvailabilityResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +18,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/products")
 public class ProductSearchController {
 
+  private final ProductSearchService searchService;
+
+  // 날짜 기준 예약 가능한 상품 조회
+  @GetMapping("/available")
+  public ApiResponse<Slice<ProductAvailabilityResponse>> getAvailableProducts(
+      @RequestParam LocalDate date,
+      Pageable pageable
+  ) {
+    Slice<ProductAvailabilityResponse> response =
+        searchService.getAvailableProducts(date, pageable)
+            .map(ProductAvailabilityResponse::from);
+
+    return ApiResponse.success(CommonSuccessCode.OK, response);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductAvailabilityResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductAvailabilityResponse.java
@@ -1,0 +1,34 @@
+package com.yeoljeong.tripmate.product.presentation.dto.response;
+
+import com.yeoljeong.tripmate.product.application.dto.result.ProductAvailabilityResult;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record ProductAvailabilityResponse(
+    UUID productId,
+    String productName,
+    String country,
+    String state,
+    String city,
+    String addressLine,
+    BigDecimal price,
+    LocalDate date,
+    int stock,
+    String status
+) {
+  public static ProductAvailabilityResponse from(ProductAvailabilityResult result) {
+    return new ProductAvailabilityResponse(
+        result.productId(),
+        result.productName(),
+        result.country(),
+        result.state(),
+        result.city(),
+        result.addressLine(),
+        result.price(),
+        result.date(),
+        result.stock(),
+        result.status()
+    );
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 날짜 기준 예약 가능한 상품 조회 API 컨트롤러 추가
- 컨트롤러 명칭을 ProductAvailabilityController로 리팩토링
- API 응답 DTO 및 HTTP 테스트 코드 작성
- #23

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 날짜 기반 상품 조회 API 엔드포인트 구현
- 응답 DTO 추가
- ProductSearchController → ProductAvailabilityController로 변경
- 관련 HTTP 테스트 코드 추가

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 날짜에 이용 가능한 상품을 조회하는 신규 API가 추가되었습니다.
  * 조회 결과에 페이지네이션(기본 페이지 크기 10)이 적용됩니다.

* **개선**
  * 상품 가용성 응답에 가격, 재고, 상태 및 위치 정보가 포함되어 더 상세한 정보를 제공합니다.
  * 기존 상품 목록 및 일정 조회 API에 기본 페이지 크기(10)가 적용되어 일관된 페이징 동작을 제공합니다.

* **기타**
  * 로컬 요청 템플릿의 기본 포트가 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->