### PR TITLE
feat: 일정 확정용 상품 조회 API 및 ProductPlanResponse 추가

### DIFF
--- a/http/company.http
+++ b/http/company.http
@@ -1,4 +1,4 @@
-@port = 62581
+@port = 8080
 @host = http://localhost:{{port}}
 @companyId = 98f0abb6-26ec-4d85-84cd-d7adde81cd10
 @userId = 00000000-0000-0000-0000-000000000000

--- a/http/product.http
+++ b/http/product.http
@@ -1,4 +1,4 @@
-@port = 8087
+@port =8080
 @host = http://localhost:{{port}}
 @companyId = 278a96ab-0527-492e-9e96-b4bd0235ddb8
 @userId = 00000000-0000-0000-0000-000000000000

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/internal/ProductFeignClientController.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/controller/internal/ProductFeignClientController.java
@@ -1,6 +1,8 @@
 package com.yeoljeong.tripmate.product.presentation.controller.internal;
 
+import com.yeoljeong.tripmate.product.application.service.query.ProductQueryService;
 import com.yeoljeong.tripmate.product.application.service.query.ProductSearchService;
+import com.yeoljeong.tripmate.product.presentation.dto.response.ProductPlanResponse;
 import com.yeoljeong.tripmate.product.presentation.dto.response.ProductScheduleInfoResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/internal/products")
 public class ProductFeignClientController {
 
+  private final ProductQueryService productQueryService;
   private final ProductSearchService productSearchService;
 
+  //일정 확정시 사용 하는 상품 정보
+  @GetMapping("/{productId}")
+  public ProductPlanResponse getProduct(
+      @PathVariable UUID productId
+  ) {
+    return ProductPlanResponse.from(
+        productQueryService.getProduct(productId)
+    );
+  }
+
+  //주문시 사용 하는 상품,스케줄 정보
   @GetMapping("/{productId}/schedules/{scheduleId}")
   public ProductScheduleInfoResponse getSchedule(
       @PathVariable UUID productId,

--- a/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductPlanResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/presentation/dto/response/ProductPlanResponse.java
@@ -1,0 +1,28 @@
+package com.yeoljeong.tripmate.product.presentation.dto.response;
+
+import com.yeoljeong.tripmate.product.application.dto.result.ProductResult;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record ProductPlanResponse(
+    UUID productId,
+    String productName,
+    String country,
+    String state,
+    String city,
+    BigDecimal price
+) {
+
+
+  public static ProductPlanResponse from(ProductResult result) {
+    return new ProductPlanResponse(
+        result.id(),
+        result.productName(),
+        result.address().getCountry().name(),
+        result.address().getState(),
+        result.address().getCity(),
+        result.price()
+    );
+
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 일정 확정용 상품 조회 API 및 ProductPlanResponse 추가
- #31  

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 일정 확정용 상품 조회 내부 controller 추가 
-  ProductPlanResponse 추가 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 상세 조회용 내부 API 엔드포인트가 추가되었습니다.
  * 상품의 ID, 이름, 위치(국가·지역·도시)와 가격 정보를 응답하는 새로운 응답 형식이 제공됩니다.

* **잡무**
  * 개발용 HTTP 요청 템플릿의 기본 포트가 8080으로 통일되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->