### PR TITLE
Feature/35 company product auth validation

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/company/presentation/controller/internal/CompanyFeignClientController.java
+++ b/src/main/java/com/yeoljeong/tripmate/company/presentation/controller/internal/CompanyFeignClientController.java
@@ -1,0 +1,33 @@
+package com.yeoljeong.tripmate.company.presentation.controller.internal;
+
+
+import com.yeoljeong.tripmate.company.application.dto.result.CompanyResult;
+import com.yeoljeong.tripmate.company.application.service.query.CompanyQueryService;
+import com.yeoljeong.tripmate.company.presentation.dto.response.CompanyResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/companies")
+public class CompanyFeignClientController {
+
+  private final CompanyQueryService queryService;
+
+  @GetMapping("/{companyId}")
+  public ApiResponse<CompanyResponse> getCompany(
+      @PathVariable UUID companyId
+  ) {
+
+    CompanyResult result = queryService.getCompany(companyId);
+    CompanyResponse response = CompanyResponse.from(result);
+
+    return ApiResponse.success(CommonSuccessCode.OK, response);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/application/service/client/CompanyClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/application/service/client/CompanyClient.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.product.application.service.client;
+
+import com.yeoljeong.tripmate.company.presentation.dto.response.CompanyResponse;
+import java.util.UUID;
+
+public interface CompanyClient {
+
+  CompanyResponse getCompany(UUID companyId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/application/service/command/ProductScheduleCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/application/service/command/ProductScheduleCommandService.java
@@ -30,7 +30,7 @@ public class ProductScheduleCommandService {
 
   /**
    * 상품 스케줄 일괄 생성
-   * - 상품 조회
+   * - 상품 존재 여부 확인
    * - 날짜 유효성 검증
    * - 날짜 범위 기반 스케줄 생성
    * - 일괄 저장 (중복은 DB UNIQUE 로 처리)
@@ -58,7 +58,7 @@ public class ProductScheduleCommandService {
 
   // ==메서드==
 
-  // 상품 조회
+  //상품 존재 여부 확인
   private Product findProduct(UUID productId) {
     return productRepository.findById(productId)
         .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/yeoljeong/tripmate/product/infrastructure/external/CompanyClientImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/infrastructure/external/CompanyClientImpl.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.product.infrastructure.external;
+
+import com.yeoljeong.tripmate.company.presentation.dto.response.CompanyResponse;
+import com.yeoljeong.tripmate.product.application.service.client.CompanyClient;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyClientImpl implements CompanyClient {
+
+  private final CompanyFeignClient companyFeignClient;
+
+  @Override
+  public CompanyResponse getCompany(UUID companyId) {
+
+    return companyFeignClient
+        .getCompany(companyId)
+        .getData();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/product/infrastructure/external/CompanyFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/product/infrastructure/external/CompanyFeignClient.java
@@ -1,0 +1,18 @@
+package com.yeoljeong.tripmate.product.infrastructure.external;
+
+import com.yeoljeong.tripmate.company.presentation.dto.response.CompanyResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+//실제 HTTP 호출
+@FeignClient(name = "company-service")
+public interface CompanyFeignClient {
+
+  @GetMapping("/internal/companies/{companyId}")
+  ApiResponse<CompanyResponse> getCompany(
+      @PathVariable UUID companyId
+  );
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,9 @@
 spring:
+  profiles:
+    active: dev
+
   application:
     name: company-service
-
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:43.200.28.227:29092}
 


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- #35
- company-service ↔ product-service 간 내부 통신을 위한 FeignClient 구조를 추가
- 내부 company 조회 API를 구현하여 업체 상태 및 권한 검증에 사용할 수 있도록 구성

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- CompanyFeignClientController 추가
- /internal/companies/{companyId} 내부 조회 API 구현
- CompanyClient 인터페이스 및 CompanyFeignClient 기반 구현 추가
- FeignClient 기반 내부 통신 테스트 완료
-  spring.profiles.active=dev 설정 추가(누락되어서)

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품 서비스에서 회사 정보를 실시간 조회해 상품과 연동할 수 있는 내부 연동 기능이 추가되었습니다.

* **설정**
  * 개발 환경(dev)이 기본 활성화 프로필로 설정되었습니다.

* **문서**
  * 내부 조회 로직에 대한 설명이 더 명확하게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->